### PR TITLE
Safety check low_cpu_mem_usage when in 4bit or 8bit

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2478,8 +2478,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                     "Setting device_map to {'':torch.cuda.current_device()}."
                     "If you want to use the model for inference, please set device_map ='auto' "
                 )
-                if low_cpu_mem_usage is None:
-                    low_cpu_mem_usage = True
+
+            if low_cpu_mem_usage is not True:
+                low_cpu_mem_usage = True
+                logger.info("Changed `low_cpu_mem_usage` to `True` as required in 4bit and 8bit")
 
             if from_tf or from_flax:
                 raise ValueError(


### PR DESCRIPTION
Currently, the check is only done for `is None` after which `low_cpu_mem_usage ` is set to True. But that can lead to unexpected behavior, especially if it is set to False. The result would be a hard-to-debug error trace (cf. related issue). This PR makes sure that when in 4bit or 8bit, `low_cpu_mem_usage` is set to True regardless of its current value and it will log a warning to the user to notify them of the change.

closes https://github.com/huggingface/accelerate/issues/1858